### PR TITLE
PHP container Add libzip-dev

### DIFF
--- a/docker-assets/php-fpm/Dockerfile
+++ b/docker-assets/php-fpm/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:7-fpm-alpine
 RUN apk add --no-cache \
         zip \
+        libzip-dev \
         libpng \
         libpng-dev \
         libjpeg \


### PR DESCRIPTION
PHP 7.3 needs libzip-dev 

install this
https://pkgs.alpinelinux.org/package/edge/community/x86/libzip-dev